### PR TITLE
Clarify coding conventions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -58,8 +58,9 @@ Coding Conventions
 * Functions should do one thing.
 * Early pull requests and code reviews.
 * Early architecting/design. Code reviews can happen before any code has been written.
-* Use a consistent character width with an upper bound of 120.
+* Use a consistent character width of 120.
 * Use 4 spaces instead of tabs.
+* End all files with a newline.
 
 Documentation and Comments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I have been interpreting "an upper bound of 120" as exactly 120. So all of my comments are wrapped at 120. I notice that there's an implicit rule to actually use 100 characters. This makes things look ugly when different authors have wrapped things differently in the same file. As well, files should end with a newline.

@randomir, @arcondello, @orenshk