### PR TITLE
WIP: All tools in left sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ build
 ######################
 *.sublime-workspace
 *.sublime-project
+
+# Dir containing sdk
+######################
+packages

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+clean:
+	rm -rf _build
+	rm -rf packages
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/conf.py
+++ b/conf.py
@@ -22,6 +22,8 @@ import importlib
 
 from subprocess import call, PIPE, Popen
 
+from dwaveoceansdk.package_info import __version__ as sdk_version
+
 mydir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, mydir)
 
@@ -47,7 +49,6 @@ for pkg_name, import_name, repo in projects:
 
     if not os.path.isdir(pkg_dir):
         call([git_path, 'clone', repo, pkg_dir])
-        # raise NotImplementedError
 
     # make sure we're pointing at the right tag rather than the most recent
     os.chdir(pkg_dir)
@@ -101,7 +102,7 @@ author = u'D-Wave Systems Inc'
 # built documents.
 #
 # The short X.Y version.
-version = '0.0.1'
+version = sdk_version
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/index.rst
+++ b/index.rst
@@ -28,6 +28,7 @@ Understand the terminology.
    :maxdepth: 2
 
    getting_started
+   packages
    projects
    glossary
    CONTRIBUTING

--- a/packages.rst
+++ b/packages.rst
@@ -1,0 +1,11 @@
+.. _packages:
+
+========
+Packages
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   packages/dimod/docs/index
+   packages/dwave-system/docs/index

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 sphinx==1.6.2
 sphinx_rtd_theme==0.4.2
 recommonmark==0.4.0 
+
+dwave-ocean-sdk


### PR DESCRIPTION
Implementation that includes dimod and dwave-system in the documentation on the left sidebar.

This is a proof of concept, several outstanding issues:
* need to add all of the packages in the sdk
* right now each package's docs are designed to stand alone so don't look very good when included as a small part of the documentation. One approach would be to include a `shortindex.rst` in each package. Something like
```
=====
dimod
=====

.. toctree::
  :maxdepth: 1

  introduction
  reference/index
  installation
  license
  Source <https://github.com/dwavesystems/dimod>
```
* have not removed the old "Tools" section, so it contains redundant info

It also relies on several assumptions:
* The existence of `package.__version__` or `package.package_info.__version__`
* The docs being in `package/docs`
* The tag matching the version (notably not true in [penaltymodel](https://github.com/dwavesystems/penaltymodel))